### PR TITLE
🐛 Disconnect the serveur on disable

### DIFF
--- a/src/main/java/fr/zorg/bungeesk/bukkit/BungeeSK.java
+++ b/src/main/java/fr/zorg/bungeesk/bukkit/BungeeSK.java
@@ -36,6 +36,10 @@ public class BungeeSK extends JavaPlugin {
     @Override
     public void onDisable() {
         Updater.get().stop();
+        if(ConnectionClient.get() != null) {
+            getLogger().info("Disconnecting from connection " + ConnectionClient.get().getAddress() + ":" + ConnectionClient.get().getPort());
+            ConnectionClient.get().disconnect();
+        }
     }
 
     public static BungeeSK getInstance() {

--- a/src/main/java/fr/zorg/bungeesk/bukkit/sockets/ConnectionClient.java
+++ b/src/main/java/fr/zorg/bungeesk/bukkit/sockets/ConnectionClient.java
@@ -222,7 +222,7 @@ public final class ConnectionClient {
                 this.reader.close();
                 this.writer.close();
                 final Event event = new ClientDisconnectEvent();
-                Bukkit.getScheduler().runTask(BungeeSK.getInstance(), () -> Bukkit.getPluginManager().callEvent(event));
+                Bukkit.getPluginManager().callEvent(event);
                 this.readThread.interrupt();
             }
         } catch (IOException e) {

--- a/src/main/java/fr/zorg/bungeesk/bungee/sockets/ClientServer.java
+++ b/src/main/java/fr/zorg/bungeesk/bungee/sockets/ClientServer.java
@@ -116,6 +116,12 @@ public final class ClientServer {
 
                 switch (header.toUpperCase()) {
                     case "DISCONNECT": {
+                        BungeeSK.getInstance().getLogger().info("§6A server has been disconnected: §a" +
+                                this.getName() +
+                                " §6(§a" +
+                                this.getSocket().getInetAddress().getHostAddress() +
+                                "§6)"
+                        );
                         this.forceDisconnect();
                         break reader;
                     }


### PR DESCRIPTION
Make servers disconnect from the proxy on BungeeSK disable, to prevent from error saying that server is already connected.